### PR TITLE
Ak96/unshare uts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Packaging: Fixed packaging for arch based.
 - Use `ostree` binary to pull files instead of the `ostree` library. This shows progress on
   downloading files.
-
-### Removed
+- Use `--unshare-uts` to set hostname instead of by hacking an environment variable.
 
 ## [0.3] - 2024-11-17
 
@@ -33,8 +32,6 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Bugfix: interruptible downloads
 - Use native overlayfs instead of fuse implementation. Requires Linux kernel 5.11+
 - Improved handling of bwrap as a dependency
-
-### Removed
 
 ## [0.2] - 2024-06-20
 

--- a/src/maps
+++ b/src/maps
@@ -280,7 +280,7 @@ def mode_run(args):
             command = tomli.load(manifest_file)
             command = command['Core']["command"]
     else:
-        command = "bash --norc"
+        command = "bash"
     if args.COMMAND:
         command = args.COMMAND
     if command == '':
@@ -293,7 +293,7 @@ def mode_run(args):
     # ignore SIGINT
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     rstatus = subprocess.run((f"{BWRAP} --forward-signals --unshare-user --unshare-pid "
-                              f"--unshare-uts --hostname=runtime --overlay-src {DATADIR}/rofs "
+                              f"--unshare-uts --hostname runtime --overlay-src {DATADIR}/rofs "
                               f"--overlay {DATADIR}/rwfs {DATADIR}/tmpfs /  --bind {HOME}/Public "
                               f"{senv['HOME']}/Public --ro-bind /sys /sys --die-with-parent "
                               f"--proc /proc --dev /dev --uid 0 --gid 0 {command}").split(),
@@ -566,9 +566,9 @@ def mode_package(repo, repopath, args):
         # ignore SIGINT
         signal.signal(signal.SIGINT, signal.SIG_IGN)
         rstatus = subprocess.run((f"{BWRAP} --forward-signals --unshare-user --unshare-pid "
-                                  f"--unshare-uts --hostname=runtime --bind {args.LOCATION} / "
+                                  f"--unshare-uts --hostname runtime --bind {args.LOCATION} / "
                                   f"--proc /proc --dev /dev --ro-bind /sys /sys --die-with-parent "
-                                  f"--uid 0 --gid 0 bash --norc").split(), env=senv, check=False)
+                                  f"--uid 0 --gid 0 bash").split(), env=senv, check=False)
         if VERBOSE:
             print("Exiting sandbox...")
         if rstatus.returncode != 0:

--- a/src/maps
+++ b/src/maps
@@ -528,7 +528,7 @@ def blank_options():
 
 
 # Package Mode
-def mode_package(repo, args):
+def mode_package(repo, repopath, args):
     """Function for package mode. Not intended to be used by "end users" """
     if args.DIR is not None:
         refhash = ''
@@ -537,7 +537,7 @@ def mode_package(repo, args):
             if VERBOSE:
                 print("base/x86_64/debian not found locally, fetching...")
             refhash = repo.remote_list_refs("Official")[1]['base/x86_64/debian']
-            download(repo, "Official", "base/x86_64/debian")
+            download(repopath, "Official", "base/x86_64/debian")
         else:
             refhash = repo.list_refs()[1]['Official:base/x86_64/debian']
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -879,7 +879,7 @@ def main():
     elif args.SubPars_NAME == 'remote':
         mode_remotes(repo, args)
     elif args.SubPars_NAME == 'package':
-        mode_package(repo, args)
+        mode_package(repo, repopath, args)
     else:
         raise ValueError("Impossible case!")
 

--- a/src/maps
+++ b/src/maps
@@ -289,16 +289,15 @@ def mode_run(args):
     print(f"Launching {args.RUN}...")
     senv = os.environ
     senv["HOME"] = "/home/runtime"
-    senv["PS1"] = "\\u@runtime:\\w# "
     senv["LC_ALL"] = "C"
     # ignore SIGINT
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     rstatus = subprocess.run((f"{BWRAP} --forward-signals --unshare-user --unshare-pid "
-                              f"--overlay-src {DATADIR}/rofs --overlay {DATADIR}/rwfs "
-                              f"{DATADIR}/tmpfs /  --bind {HOME}/Public {senv['HOME']}/Public "
-                              f"--ro-bind /sys /sys --die-with-parent --proc /proc --dev /dev "
-                              f"--uid 0 --gid 0 {command}").split(), env=senv,
-                             check=False)
+                              f"--unshare-uts --hostname=runtime --overlay-src {DATADIR}/rofs "
+                              f"--overlay {DATADIR}/rwfs {DATADIR}/tmpfs /  --bind {HOME}/Public "
+                              f"{senv['HOME']}/Public --ro-bind /sys /sys --die-with-parent "
+                              f"--proc /proc --dev /dev --uid 0 --gid 0 {command}").split(),
+                             env=senv, check=False)
     if rstatus.returncode != 0:
         print(f"Sandbox exited with return code {rstatus.returncode}")
     elif VERBOSE:
@@ -563,14 +562,13 @@ def mode_package(repo, args):
         print(f"Launching a sandbox in {args.LOCATION}...")
         senv = os.environ
         senv["HOME"] = "/home/runtime"
-        senv["PS1"] = "\\u@runtime:\\w# "
         senv["LC_ALL"] = "C"
         # ignore SIGINT
         signal.signal(signal.SIGINT, signal.SIG_IGN)
-        rstatus = subprocess.run((f"{BWRAP} --forward-signals --unshare-user --unshare-pid --bind "
-                                  f"{args.LOCATION} / --proc /proc --dev /dev --ro-bind /sys /sys "
-                                  f"--die-with-parent --uid 0 --gid 0 bash --norc").split(),
-                                 env=senv, check=False)
+        rstatus = subprocess.run((f"{BWRAP} --forward-signals --unshare-user --unshare-pid "
+                                  f"--unshare-uts --hostname=runtime --bind {args.LOCATION} / "
+                                  f"--proc /proc --dev /dev --ro-bind /sys /sys --die-with-parent "
+                                  f"--uid 0 --gid 0 bash --norc").split(), env=senv, check=False)
         if VERBOSE:
             print("Exiting sandbox...")
         if rstatus.returncode != 0:


### PR DESCRIPTION
Add `--unshare-uts` to bwrap invocation, so that we don't need to overwrite PS1 to show `root@runtime` as prompt.

Just a less hacky way to get a pretty prompt. It might have some other consequences which I don't fully foresee.