### PR TITLE
Ak96/syft bom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 
 ### Added
 - Add `--export-tar` option to export a runtime to a tarball.
+- Add generation of a Software Bill of Materials (SBOM) while generating a tarball, if `syft` is
+  already installed.
 
 ### Changed
 

--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -20,6 +20,7 @@ depends=('base-devel'
          'python-gobject'
          'python-progress'
          'python-tuspy'
+         'syft'
          'xdg-utils'
          )
 conflicts=('maps')

--- a/src/maps
+++ b/src/maps
@@ -1386,7 +1386,6 @@ def runtime_to_tar(repo, runtime, remote=None):
     RUNTIMEDIR = f"{DATADIR}/{remote}/{runtime}/rofs"
     REFHASH = repo.list_refs()[1][runtime]
     TARPATH = f"{DATADIR}/{remote}/{':'.join(runtime.split('/'))}.tar.gz"
-
     # if runtime is not checked out, do it
     if not os.path.isdir(RUNTIMEDIR):
         checkout(repo, remote, runtime)

--- a/src/maps
+++ b/src/maps
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 import argparse
 import concurrent.futures
+from shutil import which
 from math import log10, floor
 from time import strftime, localtime
 from urllib import request
@@ -1393,6 +1394,17 @@ def runtime_to_tar(repo, runtime, remote=None):
 
     # if the refhash matches tar hash, don't re-tar
     if needs_tar(REFHASH, TARPATH, DATADIR):
+        if which("syft") is not None:
+            if VERBOSE:
+                print("Adding Software Bill of Materials")
+            sbom = subprocess.run(
+                f"syft scan {RUNTIMEDIR} -o spdx-json --source-name={runtime}".split(),
+                capture_output=True,
+                check=True
+            )
+            sbom = json.loads(sbom.stdout.decode())
+            with open(f"{RUNTIMEDIR}/sbom.spdx", 'w', encoding="UTF-8") as sbomfile:
+                json.dump(sbom, sbomfile)
         if VERBOSE:
             print("Making tarball...")
             opts = "-cv --use-compress-program=pigz"
@@ -1402,6 +1414,8 @@ def runtime_to_tar(repo, runtime, remote=None):
         subprocess.run(f"tar {opts} -C {RUNTIMEDIR[0:-4]} -f {TARPATH} {RUNTIMEDIR[-4:]}".split(),
                        check=True)
         add_hash_to_db(REFHASH, TARPATH, DATADIR)
+        if which("syft") is not None:
+            os.remove(f"{RUNTIMEDIR}/sbom.spdx")
 
     return TARPATH
 

--- a/src/maps
+++ b/src/maps
@@ -473,7 +473,8 @@ def disambiguate_runtime(repo: OSTree.Repo, rrstring: str, installed: bool = Tru
 
         if found:
             # found something with the same name installed, assume we want that, with a warning
-            print(f"{COLORS['WARNING']}Warning, possibly ambigious name. Assuming {remote}:{runtime}{COLORS['ENDC']}")
+            print(f"{COLORS['WARNING']}Warning, possibly ambigious name. Assuming "
+                  f"{remote}:{runtime}{COLORS['ENDC']}")
             return remote, runtime
 
         # all known remotes

--- a/src/maps
+++ b/src/maps
@@ -473,7 +473,7 @@ def disambiguate_runtime(repo: OSTree.Repo, rrstring: str, installed: bool = Tru
 
         if found:
             # found something with the same name installed, assume we want that, with a warning
-            print(f"warning, possibly ambigious name. Assuming {remote}:{runtime}")
+            print(f"{COLORS['WARNING']}Warning, possibly ambigious name. Assuming {remote}:{runtime}{COLORS['ENDC']}")
             return remote, runtime
 
         # all known remotes

--- a/src/maps
+++ b/src/maps
@@ -1386,6 +1386,7 @@ def runtime_to_tar(repo, runtime, remote=None):
     RUNTIMEDIR = f"{DATADIR}/{remote}/{runtime}/rofs"
     REFHASH = repo.list_refs()[1][runtime]
     TARPATH = f"{DATADIR}/{remote}/{':'.join(runtime.split('/'))}.tar.gz"
+
     # if runtime is not checked out, do it
     if not os.path.isdir(RUNTIMEDIR):
         checkout(repo, remote, runtime)

--- a/src/maps
+++ b/src/maps
@@ -1406,6 +1406,12 @@ def runtime_to_tar(repo, runtime, remote=None):
             sbom = json.loads(sbom.stdout.decode())
             with open(f"{RUNTIMEDIR}/sbom.spdx", 'w', encoding="UTF-8") as sbomfile:
                 json.dump(sbom, sbomfile)
+        else:
+            if VERBOSE:
+                print(
+                    f"{COLORS['WARNING']}syft was not found. SBOM will not be generated"
+                    f"{COLORS['ENDC']}"
+                )
         if VERBOSE:
             print("Making tarball...")
             opts = "-cv --use-compress-program=pigz"


### PR DESCRIPTION
Requires #64 

Adds a SBOM to the generated tarball when exporting a runtime

This depends on [anchore/syft](https://github.com/anchore/syft), but silently doesn't happen if syft was not found installed on the host.